### PR TITLE
packagegroup: add missing sema4.0 util for adlink boards

### DIFF
--- a/recipes-adlink/packagegroups/packagegroup-adlink-tools.bb
+++ b/recipes-adlink/packagegroups/packagegroup-adlink-tools.bb
@@ -93,6 +93,7 @@ RDEPENDS_packagegroup-adlink-bluetooth = " \
 SUMMARY_packagegroup-adlink-tools = "Adlink Tools Support"
 RDEPENDS_packagegroup-adlink-tools = " \
     adlink-imx8mp-startup \
+    sema4.0 \
     test-tools \
     mraa \
     mraa-dev \


### PR DESCRIPTION
Forgot sema4.0 for adlink boards

Signed-off-by: po.cheng <po.cheng@adlinktech.com>