### PR TITLE
packagegroup-adlink-tools: Fix inclusion of sema 4.0 with full bsp me…

### DIFF
--- a/recipes-adlink/packagegroups/packagegroup-adlink-tools.bb
+++ b/recipes-adlink/packagegroups/packagegroup-adlink-tools.bb
@@ -111,7 +111,7 @@ RDEPENDS_packagegroup-adlink-tools = " \
     upm-dev \
     python3-upm \
     python3-mraa \
-    ${@bb.utils.contains('BBLAYERS', 'meta-adlink-sema', 'sema', '', d)} \
+    ${@bb.utils.contains('BBLAYERS', '${BSPDIR}/sources/meta-adlink-sema', 'sema', '', d)} \
 "
 
 SUMMARY_packagegroup-adlink-utils = "Adlink Utils Support"


### PR DESCRIPTION
Fix sema not included depending on full path of meta-adlink-sema bsp layer