### PR TITLE
Update to 1v7

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,17 @@
 
 ## LEC-IMX8MP
 
+### v1.7
+2021-08-30
+
+### Fixes
+- Fix RDEPENDS packagegroup spelling mistake for wifi and bluetooth
+- Add FCC specific mfg firmwares for nxp WIFI/BT sd8997 module
+- Work-around patch for WIFI/BT sd8997 driver to enable private ioctls (iwpriv)
+- Start the mfgbridge as an systemd service for adlink-image-fcc
+- Fix inclusion of sema4.0 using full bsp meta-adlink-sema path
+- set IO4 on ioexpander enable output on ethernet levelshift
+
 ### v1.6
 2021-07-06
 

--- a/conf/adlink-conf/adlink-imx-setup-release.sh
+++ b/conf/adlink-conf/adlink-imx-setup-release.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 TOKEN_PRE="ghp_"
-TOKEN_POST="n4138GgHZwaS7MChjf83NeQD2E7iUt01u9po"
+TOKEN_POST="iGvgyyrnRFoA71UrF0N12vm6pqEIFi0xgPs7"
 
 if [ -z "$BUILD" ]; then
 	BUILD=build

--- a/recipes-adlink/images/adlink-image-fcc.bb
+++ b/recipes-adlink/images/adlink-image-fcc.bb
@@ -36,6 +36,9 @@ IMAGE_LINGUAS = ""
 
 LICENSE = "MIT"
 
+inherit distro_features_check
+REQUIRED_DISTRO_FEATURES = "fcc"
+
 inherit core-image
 
 # Following is for appearance as we are only building /boot vfat partition

--- a/recipes-adlink/packagegroups/packagegroup-adlink-tools.bb
+++ b/recipes-adlink/packagegroups/packagegroup-adlink-tools.bb
@@ -103,6 +103,7 @@ RDEPENDS_packagegroup-adlink-tools = " \
     adlink-imx8mp-startup \
     test-tools \
     powerled \
+    eth-lsoe \
     mraa \
     mraa-dev \
     mraa-doc \

--- a/recipes-connectivity/fcc-mfgbridge/adlink-fcc-mfgbridge_git.inc
+++ b/recipes-connectivity/fcc-mfgbridge/adlink-fcc-mfgbridge_git.inc
@@ -6,7 +6,7 @@ ADLINK_SRC ?= "git://github.com/ADLINK/mwifiex-adlink.git"
 
 SRCBRANCH = "adlink-bridge-0.1.0.43"
 SRC_URI = "${ADLINK_SRC};branch=${SRCBRANCH};protocol=https;user=${PA_USER}:${PA_TOKEN};"
-SRCREV = "8a40ea40a6aa9a9b24be995016685feb888537c8"
+SRCREV = "2e2c7e0a1d5b733aa5398c6d3e6cc57dd68b8f52"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-connectivity/fcc-mfgbridge/fcc-mfgbridge.bb
+++ b/recipes-connectivity/fcc-mfgbridge/fcc-mfgbridge.bb
@@ -2,6 +2,11 @@ require adlink-fcc-mfgbridge_git.inc
 
 SUMMARY = "Marvell mfgbridge app for FCC wifi/bt"
 
+SRC_URI += "file://fcc-mfgbridge.service"
+
+inherit distro_features_check
+REQUIRED_DISTRO_FEATURES = "systemd fcc"
+
 DEPENDS += "bluez5 linux-libc-headers"
 
 DEBUG_FLAGS = ""
@@ -21,9 +26,16 @@ do_install () {
     cp -f ${S}/bridge_linux_0.1.0.43/bin_mfgbridge/mfgbridge ${D}${sbindir}/
     install -d ${D}${sysconfdir}/
     cp -f ${S}/bridge_linux_0.1.0.43/bin_mfgbridge/bridge_init.conf ${D}${sysconfdir}/
+    # systemd mfgbridge service
+    install -d ${D}${systemd_unitdir}/system/
+    install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+    install -m 0644 ${WORKDIR}/fcc-mfgbridge.service ${D}${systemd_unitdir}/system
+    # enable the service
+    ln -sf ${systemd_unitdir}/system/fcc-mfgbridge.service \
+            ${D}${sysconfdir}/systemd/system/multi-user.target.wants/fcc-mfgbridge.service
 }
 
-FILES_${PN} = "${sbindir} ${sysconfdir}"
+FILES_${PN} = "${sbindir} ${sysconfdir} ${systemd_unitdir}/system/fcc-mfgbridge.service ${sysconfdir}/systemd/system/multi-user.target.wants/fcc-mfgbridge.service"
 
 INSANE_SKIP_${PN} = "ldflags"
 

--- a/recipes-connectivity/fcc-mfgbridge/files/fcc-mfgbridge.service
+++ b/recipes-connectivity/fcc-mfgbridge/files/fcc-mfgbridge.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=FCC MFG Bridge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/mfgbridge
+Restart=always
+RestartSec=10
+TimeoutSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-extended/eth-lfoe/eth-lsoe/eth-lsoe.service
+++ b/recipes-extended/eth-lfoe/eth-lsoe/eth-lsoe.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=ADLINK to turn on BMC Green (Power) LED Service
+After=multi-user.target
+AllowIsolate=yes
+
+[Service]
+Type=oneshot
+# Start grow partition on system default rootfs
+ExecStart=/usr/bin/powerled.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-extended/eth-lfoe/eth-lsoe/eth-lsoe.sh
+++ b/recipes-extended/eth-lfoe/eth-lsoe/eth-lsoe.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+##########################
+# Author: Po Cheng       #
+# Date: 24/06/2021       #
+##########################
+
+if [ $# -gt 0 -a $# -le 6 ]; then
+  echo "syntax: eth-lsoe.sh <I2C_BUS> <I2C_ADDR> <REG_DIR> <REG_DATA> <REG_DATA_MASK>"
+  exit 1
+fi
+
+I2C_BUS=${1:-4}
+I2C_ADDR=${2:-0x70}
+REG_DIR=${3:-0x0f}
+REG_DATA=${4:-0x11}
+REG_DATA_MASK=${5:-0x10}
+
+# direction on ioexpander
+DIRECTION=$( i2cget -f -y $I2C_BUS $I2C_ADDR $REG_DIR )
+# from 3f => 1f
+DIRECTION=$(( $DIRECTION & ( ~ $REG_DATA_MASK ) ))
+i2cset -f -y $I2C_BUS $I2C_ADDR $REG_DIR $DIRECTION
+
+# value on iopexpander
+VALUE=$( i2cget -f -y $I2C_BUS $I2C_ADDR $REG_DATA )
+# from cf => ef
+VALUE=$(( $VALUE | $REG_DATA_MASK ))
+i2cset -f -y $I2C_BUS $I2C_ADDR $REG_DATA $VALUE

--- a/recipes-extended/eth-lfoe/eth-lsoe_1.0.bb
+++ b/recipes-extended/eth-lfoe/eth-lsoe_1.0.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Script to enable ethernet level shift output enable"
+DESCRIPTION = "Ethernet LevelShit Output Enable script"
+SECTION = "app"
+LICENSE = "GPLv3"
+LICENSE_FLAGS = "commercial_adlink"
+
+LIC_FILES_CHKSUM = "file://eth-lsoe.sh;md5=b5bac77068148f614a5f919b791b3c8e"
+
+SRC_URI = " \
+    file://eth-lsoe.sh \
+    file://eth-lsoe.service \
+"
+
+S = "${WORKDIR}"
+
+do_compile[noexec] = "1"
+
+do_install () {
+	# add the service to systemd
+	install -d ${D}${systemd_unitdir}/system/
+	install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+	install -m 0644 ${S}/eth-lsoe.service ${D}${systemd_unitdir}/system/
+	# enable the service
+	ln -sf ${systemd_unitdir}/system/eth-lsoe.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/eth-lsoe.service
+
+	# install eth-lsoe script
+	install -d ${D}${bindir}
+	install -m 0755 ${S}/eth-lsoe.sh ${D}${bindir}/
+}
+
+FILES_${PN} += "${bindir}"
+FILES_${PN} += "${systemd_unitdir}/system/"
+FILES_${PN} += "${sysconfdir}/systemd/system/multi-user.target.wants/"
+
+RDEPENDS_${PN} += "bash i2c-tools"
+
+LICENSE_FLAGS_WHITELIST += "commercial_adlink"

--- a/recipes-kernel/kernel-modules/kernel-module-bt-sd8997/blacklist.conf
+++ b/recipes-kernel/kernel-modules/kernel-module-bt-sd8997/blacklist.conf
@@ -1,0 +1,1 @@
+blacklist bt8xxx

--- a/recipes-kernel/kernel-modules/kernel-module-bt-sd8997_1.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-bt-sd8997_1.0.bb
@@ -7,6 +7,10 @@ SUMMARY = "bt driver for NXP-W9887 WIFI/BT module"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
+SRC_URI_append = " \
+  file://blacklist.conf \
+"
+
 inherit module
 
 DEPENDS = "virtual/kernel"
@@ -19,3 +23,15 @@ EXTRA_OEMAKE += " \
 # CONFIG_SDIO_SUSPEND_RESUME=y     -> SDIO suspend/resume
 
 S = "${WORKDIR}/git/mbtex_8997"
+
+MODPROBE_CONFFILE = "${@bb.utils.contains('DISTRO_FEATURES', 'fcc', 'blacklist.conf', '', d)}"
+
+do_install_append () {
+  install -d ${D}${sysconfdir}/modprobe.d
+  if [ -f ${WORKDIR}/${MODPROBE_CONFFILE} ]; then
+    install -m 644 ${WORKDIR}/${MODPROBE_CONFFILE} ${D}${sysconfdir}/modprobe.d/
+  fi
+}
+
+FILES_${PN} += "${sysconfdir}/modprobe.d"
+

--- a/recipes-kernel/kernel-modules/kernel-module-sd8997/sd8xxx-fcc.conf
+++ b/recipes-kernel/kernel-modules/kernel-module-sd8997/sd8xxx-fcc.conf
@@ -1,0 +1,2 @@
+options sd8xxx mfg_mode=1 drv_mode=1 fw_name=nxp/sdio8997_sdio_combo.bin cal_data_cfg=none
+

--- a/recipes-kernel/kernel-modules/kernel-module-sd8997_1.0.bb
+++ b/recipes-kernel/kernel-modules/kernel-module-sd8997_1.0.bb
@@ -7,7 +7,10 @@ SUMMARY = "moal driver for NXP-W9887 WIFI/BT module via sdio"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-SRC_URI_append = " file://sd8xxx.conf"
+SRC_URI_append = " \
+  file://sd8xxx.conf \
+  file://sd8xxx-fcc.conf \
+"
 
 inherit module
 
@@ -39,9 +42,12 @@ EXTRA_OEMAKE += " \
 
 S = "${WORKDIR}/git/mwifiex_8997"
 
+MODPROBE_CONFFILE = "${@bb.utils.contains('DISTRO_FEATURES', 'fcc', 'sd8xxx-fcc.conf', 'sd8xxx.conf', d)}"
+
 do_install_append () {
    install -d ${D}${sysconfdir}/modprobe.d
-   install -m 644 ${WORKDIR}/sd8xxx.conf ${D}${sysconfdir}/modprobe.d
+   # if building wifi/bt, then copy sd8xxx.conf
+   install -m 644 ${WORKDIR}/${MODPROBE_CONFFILE} ${D}${sysconfdir}/modprobe.d/sd8xxx.conf
 }
 
 FILES_${PN} += "${sysconfdir}/modprobe.d"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -3,27 +3,26 @@
 # Support additional firmware for nxp 88w8997 sdio wifi/bt module
 #
 
-SRCREV_adlink-sd8997 ?= "caffd392e9e061419787e0cd38a460b4ec7062d1"
+SRCREV_adlink-sd8997 ?= "3039b67d7dc9196c7851fbc5d9a8c0e7e7874a09"
 ADLINK_FIRMWARE_SRC ?= "git://github.com/ADLINK/nxp-w8997-fwimage.git"
 ADLINK_SRCBRANCH ?= "main"
 SRC_URI_append_wifibt = "\
     ${ADLINK_FIRMWARE_SRC};branch=${ADLINK_SRCBRANCH};protocol=https;user=${PA_USER}:${PA_TOKEN};name=adlink-sd8997;destsuffix=adlink-sd8997 \
 "
 
+SD8997_FWDIR := "${@bb.utils.contains('DISTRO_FEATURES', 'fcc', 'FwImageFcc', 'FwImage', d)}"
+
 do_install_append_wifibt () {
     # Install NXP Connectivity sd8997 firmware
-    install -m 0644 ${WORKDIR}/adlink-sd8997/FwImage/sdsd8997_combo_v4.bin ${D}/lib/firmware/nxp
-    install -m 0644 ${WORKDIR}/adlink-sd8997/FwImage/sd8997_wlan_v4.bin ${D}/lib/firmware/nxp
-    install -m 0644 ${WORKDIR}/adlink-sd8997/FwImage/sd8997_bt_v4.bin ${D}/lib/firmware/nxp
-    install -m 0644 ${WORKDIR}/adlink-sd8997/FwImage/r3p_R0_X8.bin ${D}/lib/firmware/nxp
+    install -d ${D}/lib/firmware/nxp
+    for binfile in ${WORKDIR}/adlink-sd8997/${SD8997_FWDIR}/*.bin; do
+      install -m 0644 ${binfile} ${D}/lib/firmware/nxp
+    done
 }
 
 PACKAGES =+ " ${PN}-sd8997"
 LICENSE_${PN}-sd8997 = "Firmware-Marvell"
 
 FILES_${PN}-sd8997_append_wifibt = " \
-    /lib/firmware/nxp/sdsd8997_combo_v4.bin \
-    /lib/firmware/nxp/sd8997_wlan_v4.bin \
-    /lib/firmware/nxp/sd8997_bt_v4.bin \
-    /lib/firmware/nxp/r3p_R0_X8.bin \
+    /lib/firmware/nxp/ \
 "

--- a/recipes-kernel/linux/linux-imx/0021-LEC-iMX8MP-patch-to-fix-wireless-private-ioctl.patch
+++ b/recipes-kernel/linux/linux-imx/0021-LEC-iMX8MP-patch-to-fix-wireless-private-ioctl.patch
@@ -1,0 +1,30 @@
+From f817f1e402b243d44117150c8ab4dae43c4f2b9c Mon Sep 17 00:00:00 2001
+From: "po.cheng" <po.cheng@adlinktech.com>
+Date: Fri, 27 Aug 2021 13:59:22 +0800
+Subject: [PATCH] linux: patch to fix wireless private ioctl not supported
+ issue.
+
+Signed-off-by: po.cheng <po.cheng@adlinktech.com>
+---
+ net/wireless/wext-core.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/net/wireless/wext-core.c b/net/wireless/wext-core.c
+index 69102fda9ebd..bf3948d8627f 100644
+--- a/net/wireless/wext-core.c
++++ b/net/wireless/wext-core.c
+@@ -955,6 +955,11 @@ static int wireless_process_ioctl(struct net *net, struct iwreq *iwr,
+ 		else if (private)
+ 			return private(dev, iwr, cmd, info, handler);
+ 	}
++
++	/* Use Old driver API : call driver's private ioctl handler */
++	if (dev && dev->netdev_ops && dev->netdev_ops->ndo_do_ioctl)
++		return dev->netdev_ops->ndo_do_ioctl(dev, (struct ifreq *)iwr, cmd);
++
+ 	return -EOPNOTSUPP;
+ }
+ 
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-imx_5.4.bbappend
+++ b/recipes-kernel/linux/linux-imx_5.4.bbappend
@@ -139,6 +139,7 @@ SRC_URI_append_lec-imx8mp += " \
 			file://0018-LEC-iMX8MP-Enable-PCIE-compliance-test.patch \
 			file://0019-LEC-iMX8MP-Changes-for-OV13855-camera-sensor.patch \
 			file://0020-LEC-iMX8MP-switch-usb-mode-to-OTG.patch \
+			file://0021-LEC-iMX8MP-patch-to-fix-wireless-private-ioctl.patch \
 "
 
 SRC_URI_append_wifibt = " \


### PR DESCRIPTION
Work-around for WIFI/BT driver to enable private ioctls
Fix FCC image due to WIFI/BT private ioctl issue.
Some additional fixed to previous recipes