### PR TITLE
dts: fix can bus dts include for 2GB

### DIFF
--- a/recipes-kernel/linux/linux-imx/0020-CAN-Add-MCB1517FD-driver-and-dts-to-kernel-5.4.47.patch
+++ b/recipes-kernel/linux/linux-imx/0020-CAN-Add-MCB1517FD-driver-and-dts-to-kernel-5.4.47.patch
@@ -85,7 +85,7 @@ index 000000000000..e974d3a68c50
 + * GNU General Public License for more details.
 + */
 +
-+#include "adlink-lec-imx8m-dual-display.dts"
++#include "adlink-lec-imx8m.dts"
 +
 +/delete-node/ &pgc_vpu;
 +/delete-node/ &vpu;


### PR DESCRIPTION
Signed-off-by: po.cheng <po.cheng@adlinktech.com>

Fix device tree includes for 2GB DDR can bus
