### PR TITLE
Fix: audio patch for tlv320aic3c

### DIFF
--- a/conf/machine/lec-imx8mp.conf
+++ b/conf/machine/lec-imx8mp.conf
@@ -23,7 +23,8 @@ EXTRA_KERNEL_PATCHES = " \
 	file://lec-imx8mp_defconfig \
 	file://0001-LEC-IMX8MP-Port-LEC-iMX8MP-platfrom-base-on-i.MX8MP.patch \
 	file://0002-DTB-modify-Makefile-to-build-lec-imx8mp-dtbs.patch \
-	file://0003-Added-tlv320aic3c-codec-support.patch \	
+	file://0003-Added-tlv320aic3c-codec-support.patch \
+	file://0006-audio-codec-support.patch \
 "
 EXTRA_KERNEL_PATCHES:append:tinycma = " file://0001-dtb-reduce-cma-size-for-adlink-imx8mp-som.patch"
 EXTRA_KERNEL_PATCHES_private = ""

--- a/conf/machine/lec-imx8mp.conf
+++ b/conf/machine/lec-imx8mp.conf
@@ -16,7 +16,7 @@ KERNEL_DEVICETREE = " \
 WIFIBT_DTB = "${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'adlink/${KERNEL_DEVICETREE_BASENAME}-wifi.dtb', '', d)}"
 KERNEL_DEVICETREE:append = " ${WIFIBT_DTB}"
 # over device tree overlay
-EXTRA_OEMAKE:append:pn-linux = " DTC_FLAGS='-@ -H epapr'"
+EXTRA_OEMAKE:append:pn-linux-imx = " DTC_FLAGS='-@ -H epapr'"
 
 # kernel patches
 EXTRA_KERNEL_PATCHES = " \
@@ -27,12 +27,12 @@ EXTRA_KERNEL_PATCHES = " \
 	file://0006-audio-codec-support.patch \
 "
 EXTRA_KERNEL_PATCHES:append:tinycma = " file://0001-dtb-reduce-cma-size-for-adlink-imx8mp-som.patch"
-EXTRA_KERNEL_PATCHES_private = ""
+EXTRA_KERNEL_PATCHES:private = ""
 EXTRA_KERNEL_DTS = " \
 	file://lec-imx8mp-auoB101UAN01-mipi-panel.dts \
 	file://lec-imx8mp-hydis-hv150ux2.dts \
 	file://lec-imx8mp.dts \
-	file://lec-imx8mp-tlv320aic3x.dts \	
+	file://lec-imx8mp-tlv320aic3x.dts \
 "
 WIFIBT_DTS = "${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'file://lec-imx8mp-wifi.dts', '', d)}"
 EXTRA_KERNEL_CMA_2G_PATCH = "${@bb.utils.contains('UBOOT_EXTRA_CONFIGS', 'LPDDR4_2GB', 'file://0003-Allocated-CMA-range-based-on-2G-Ram-Size.patch', '', d)}"

--- a/recipes-kernel/linux/linux-imx_5.15.bbappend
+++ b/recipes-kernel/linux/linux-imx_5.15.bbappend
@@ -7,7 +7,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 #SRCREV_private = "925f549eadf84f591d0233357c8adfaa52f9d480"
 
 EXTRA_SRC = "${@d.getVarFlag('KERNEL_SRC_PATCHES', d.getVar('MACHINE'), True)}"
-EXTRA_SRC += "file://0006-audio-codec-support.patch"
 SRC_URI:append = " ${EXTRA_SRC}"
 
 do_copy_source () {


### PR DESCRIPTION
Please be careful when patching kernels.
Specify the patch file in the machine conf in EXTRA_KERNEL_PATCHES
DO NOT add directly to EXTRA_SRC.
Otherwise, it will fail to patch (or corrupt) kernels of other projects.
