### PR TITLE
sp2-imx8mp: machine: remove redundant SAI audio patches to linux-imx

### DIFF
--- a/conf/machine/sp2-imx8mp.conf
+++ b/conf/machine/sp2-imx8mp.conf
@@ -37,10 +37,6 @@ EXTRA_KERNEL_PATCHES = " \
 	file://0004-sp2-imx8mp-patch-sgtl5000-switch-to-highest-voltage-.patch \
 	file://0005-sp2-imx8mp-patch-core.c-allow-dual-role-for-imx8mp-w.patch \
 	file://0006-sp2-imx8mp-patch-panel-simple-move-ampire-am1024600d.patch \
-	file://0007-sp2-imx8mp-patch-snd-fsl-sai-provide-mclk-TODO.patch \
-	file://0008-sp2-imx8mp-patch-snd-fsl-sai-enable-transmitter-when.patch \
-	file://0009-sp2-imx8mp-patch-snd-sgtl5000-enable-mclk-only-when-.patch \
-	file://0010-sp2-imx8mp-patch-snd-sgtl5000-fixup-enable-mclk-only.patch \
 	file://0011-sp2-imx8mp-patch-panel-simple-parse-additional-delay.patch \
 	file://0012-sp2-imx8mp-patch-pwm-backlight-add-pre-pwm-on-delay-.patch \
 	file://0013-sp2-imx8mp-patch-panel-lvds-introduce-delays-to-tune.patch \
@@ -155,4 +151,6 @@ do_image_wic[depends] += "parted-native:do_populate_sysroot \
                           dosfstools-native:do_populate_sysroot \
                           e2fsprogs-native:do_populate_sysroot \
                           u-boot-script:do_install"
+
+ACCEPT_FSL_EULA = "1"
 


### PR DESCRIPTION
Remove redundant kernel patches for sp2imx8mp