### PR TITLE
sp2-imx8mp: u-boot-script: parse eth=0 to disable eqos leaving fec en…

### DIFF
--- a/conf/machine/sp2-imx8mp.conf
+++ b/conf/machine/sp2-imx8mp.conf
@@ -20,6 +20,7 @@ KERNEL_DEVICETREE = " \
 	adlink/awcm276masur-overlay.dtbo \
 	adlink/awcm276mapur-overlay.dtbo \
 	adlink/eth0-overlay.dtbo \
+	adlink/eth1-overlay.dtbo \
 	adlink/cma950mb-overlay.dtbo \
 	adlink/cma750mb-overlay.dtbo \
 	adlink/cma400mb-overlay.dtbo \
@@ -56,6 +57,7 @@ EXTRA_KERNEL_DTS = " \
     file://awcm276masur-overlay.dts \
     file://awcm276mapur-overlay.dts \
     file://eth0-overlay.dts \
+    file://eth1-overlay.dts \
     file://cma950mb-overlay.dts \
     file://cma750mb-overlay.dts \
     file://cma400mb-overlay.dts \

--- a/recipes-bsp/u-boot/u-boot-script/overlay.scr
+++ b/recipes-bsp/u-boot/u-boot-script/overlay.scr
@@ -17,6 +17,9 @@ if test -n ${E_eth}; then
   if test ${E_eth} = 1; then
     setenv overlays ${overlays} eth0-overlay.dtbo;
   fi
+  if test ${E_eth} = 0; then
+    setenv overlays ${overlays} eth1-overlay.dtbo;
+  fi
 fi;
 if test -n ${E_wl}; then
   if test ${E_wl} = sur; then

--- a/recipes-kernel/linux/linux-imx/eth1-overlay.dts
+++ b/recipes-kernel/linux/linux-imx/eth1-overlay.dts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2023 ADLINK Technology Corp.
+ *
+ * Author: Po Cheng <po.cheng@adlinktech.com>
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&eqos>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};
+


### PR DESCRIPTION
Update to disable eth1(TSN) if specified eth=0 in eeprom.