### PR TITLE
sp2imx8mp - fix regulator error and ethernet port 1 auto-detection

### DIFF
--- a/recipes-kernel/linux/linux-imx/sp2-imx8mp/0009-sp2-imx8mp-patch-pwm-bl-and-panel-lvds-move-power-of.patch
+++ b/recipes-kernel/linux/linux-imx/sp2-imx8mp/0009-sp2-imx8mp-patch-pwm-bl-and-panel-lvds-move-power-of.patch
@@ -1,19 +1,19 @@
-From fc895444ccd655885e1e9958124165f40cbf8cb3 Mon Sep 17 00:00:00 2001
+From 2af3f49161a6f43d183e9fef16c9066f685b6592 Mon Sep 17 00:00:00 2001
 From: "po.cheng" <po.cheng@adlinktech.com>
 Date: Fri, 1 Dec 2023 11:27:52 +0800
-Subject: [PATCH 09/15] sp2-imx8mp: patch: pwm-bl and panel-lvds: move power
- off at pwm-bl to panel-lvds for timing, due to hardware design limitation on
+Subject: [PATCH] sp2-imx8mp: patch: pwm-bl and panel-lvds: move power off at
+ pwm-bl to panel-lvds for timing, due to hardware design limitation on
  sp2imx8mp
 
 Signed-off-by: po.cheng <po.cheng@adlinktech.com>
 ---
- drivers/gpu/drm/panel/panel-lvds.c | 20 ++++++++++++--------
+ drivers/gpu/drm/panel/panel-lvds.c | 28 ++++++++++++++++++----------
  drivers/video/backlight/pwm_bl.c   | 10 ++++++++--
  include/linux/pwm_backlight.h      |  1 +
- 3 files changed, 21 insertions(+), 10 deletions(-)
+ 3 files changed, 27 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/gpu/drm/panel/panel-lvds.c b/drivers/gpu/drm/panel/panel-lvds.c
-index daf9b80f6bb27..6d8ec34a38fab 100644
+index daf9b80f6bb27..d57ab96241cb6 100644
 --- a/drivers/gpu/drm/panel/panel-lvds.c
 +++ b/drivers/gpu/drm/panel/panel-lvds.c
 @@ -42,6 +42,7 @@ struct panel_lvds {
@@ -24,7 +24,22 @@ index daf9b80f6bb27..6d8ec34a38fab 100644
  	unsigned int enable_delay;
  	unsigned int post_prepare_delay;
  	unsigned int pre_disable_delay;
-@@ -81,13 +82,16 @@ static int panel_lvds_prepare(struct drm_panel *panel)
+@@ -67,8 +68,12 @@ static int panel_lvds_unprepare(struct drm_panel *panel)
+ 	if (lvds->disable_delay)
+ 		msleep(lvds->disable_delay);
+ 
+-	if (lvds->supply)
+-		regulator_disable(lvds->supply);
++	/* if skip_blpwr_off is set, then don't disable supply. Leave it for blpwm to disable.
++	   NOTE: supply regulator must be the same regulator as the blpwm power-supply */
++	if (!lvds->skip_blpwr_off) {
++		if (lvds->supply)
++			regulator_disable(lvds->supply);
++	}
+ 
+ 	if (lvds->post_unprepare_delay)
+ 		msleep(lvds->post_unprepare_delay);
+@@ -81,13 +86,16 @@ static int panel_lvds_prepare(struct drm_panel *panel)
  	struct panel_lvds *lvds = to_panel_lvds(panel);
  
  	if (lvds->supply) {
@@ -48,7 +63,7 @@ index daf9b80f6bb27..6d8ec34a38fab 100644
  		}
  	}
  
-@@ -197,7 +201,7 @@ static int panel_lvds_parse_dt(struct panel_lvds *lvds)
+@@ -197,7 +205,7 @@ static int panel_lvds_parse_dt(struct panel_lvds *lvds)
  	lvds->post_unprepare_delay = 0;
  	of_property_read_u32(np, "post-unprepare-delay-ms",
  			     &lvds->post_unprepare_delay);

--- a/recipes-kernel/linux/linux-imx/sp2-imx8mp/sp2imx8mp.dts
+++ b/recipes-kernel/linux/linux-imx/sp2-imx8mp/sp2imx8mp.dts
@@ -331,7 +331,6 @@
 	snps,force_thresh_dma_mode;
 	snps,mtl-tx-config = <&mtl_tx_setup>;
 	snps,mtl-rx-config = <&mtl_rx_setup>;
-	fsl,magic-packet;
 	status = "okay";
 
 	mdio {
@@ -343,9 +342,9 @@
 			compatible = "ethernet-phy-ieee802.3-c22";
 			reg = <1>;
 			eee-broken-1000t;
-			interrupt-parent = <&gpio4>;
-			interrupts = <22 IRQ_TYPE_LEVEL_LOW>;
-			wakeup-source;
+			reset-gpios = <&gpio4 22 GPIO_ACTIVE_LOW>;
+			reset-assert-us = <10000>;
+			reset-deassert-us = <80000>;
 			realtek,clkout-disable;
 		};
 	};


### PR DESCRIPTION
Fix regulator error for 7inch lvds panel with skip_blpwr_off flag.
Disable WoL on eqos (Ethernet 1 port), so auto-detection would work.