### PR TITLE
LEC-IMX8MP: Replace linux-firmware-nxp89xx with firmware-nxp-wifi for 6.6.52 support

### DIFF
--- a/recipes-adlink/packagegroups/packagegroup-adlink.bbappend
+++ b/recipes-adlink/packagegroups/packagegroup-adlink.bbappend
@@ -1,5 +1,5 @@
 RDEPENDS:packagegroup-adlink-wifi:append:lec-imx8mp = " \
-    linux-firmware-nxp89xx \
+    firmware-nxp-wifi \
     linux-firmware-nxp8997-sdio \
     linux-firmware-nxp8997-common \	
     nxp-wlan-sdk \


### PR DESCRIPTION
LEC-IMX8MP: Replace linux-firmware-nxp89xx with firmware-nxp-wifi for 6.6.52 support