### PR TITLE
LEC-IMX8MM: Update to use blacklist-eth.conf instead of blacklist.conf for 6.6.52

### DIFF
--- a/recipes-multimedia/r8168/r8168.bb
+++ b/recipes-multimedia/r8168/r8168.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/AdlinkCCoE/r8168.git;branch=${SRCBRANCH};protocol=ht
 
 SRC_URI:append ="file://Makefile \
 		 file://0001-r8168_n-downgrade-kernel-apis.patch \
-		 file://blacklist.conf "
+		 file://blacklist-eth.conf "
 
 S = "${WORKDIR}/git"
 
@@ -25,7 +25,7 @@ do_compile:prepend() {
 	cp ${WORKDIR}/Makefile ${WORKDIR}/git/Makefile
 }
 
-MODPROBE_CONFFILE = "blacklist.conf"
+MODPROBE_CONFFILE = "blacklist-eth.conf"
 
 do_install:append () {
   install -d ${D}${sysconfdir}/modprobe.d


### PR DESCRIPTION
Update to use blacklist-eth.conf instead of blacklist.conf for 6.6.52