### PR TITLE
LEC-IMX8MM: Add meta-chromium layer in bblayers.conf for 6.6.52 support

### DIFF
--- a/conf/adlink-conf/lec-imx8mm/bblayers.conf.append
+++ b/conf/adlink-conf/lec-imx8mm/bblayers.conf.append
@@ -1,7 +1,8 @@
-
+BBLAYERS += "${BSPDIR}/sources/meta-browser/meta-chromium"
 # ADLINK Yocto Project Release layers
 BBLAYERS += "${BSPDIR}/sources/meta-adlink-nxp"
 BBLAYERS += "${BSPDIR}/sources/meta-adlink-demo"
+
 
 # Additional from open-embedded for meta-adlink-demo xfce recipes
 BBLAYERS += "${BSPDIR}/sources/meta-openembedded/meta-xfce"


### PR DESCRIPTION
LEC-IMX8MM: Add meta-chromium layer in bblayers.conf for 6.6.52 support