### PR TITLE
LEC-IMX8MM: Rename blacklist.conf to blacklist-eth.conf and blacklist-wifi-bt.conf for 6.6.52 support

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan/blacklist.conf
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan/blacklist.conf
@@ -1,2 +1,0 @@
-blacklist mlan
-blacklist moal

--- a/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bbappend
+++ b/recipes-kernel/kernel-modules/kernel-module-nxp-wlan_git.bbappend
@@ -5,11 +5,11 @@ SRC_URI:append = " \
   file://moal.conf \
 "
 SRC_URI:append:lec-imx8mm = " \
-  file://blacklist.conf \
+  file://blacklist-wifi-bt.conf \
 "
 
 MOD_CONF_FILES = "${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'moal.conf', '', d)}"
-MOD_CONF_FILES:append:lec-imx8mm = " blacklist.conf"
+MOD_CONF_FILES:append:lec-imx8mm = " blacklist-wifi-bt.conf"
 
 do_install:append () {
   install -d ${D}${sysconfdir}/modprobe.d

--- a/recipes-multimedia/r8168/r8168.bb
+++ b/recipes-multimedia/r8168/r8168.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/AdlinkCCoE/r8168.git;branch=${SRCBRANCH};protocol=ht
 
 SRC_URI:append ="file://Makefile \
 		 file://0001-r8168_n-downgrade-kernel-apis.patch \
-		 file://blacklist.conf "
+		 file://blacklist-eth.conf "
 
 S = "${WORKDIR}/git"
 
@@ -25,7 +25,7 @@ do_compile:prepend() {
 	cp ${WORKDIR}/Makefile ${WORKDIR}/git/Makefile
 }
 
-MODPROBE_CONFFILE = "blacklist.conf"
+MODPROBE_CONFFILE = "blacklist-eth.conf"
 
 do_install:append () {
   install -d ${D}${sysconfdir}/modprobe.d

--- a/recipes-multimedia/r8168/r8168/blacklist.conf
+++ b/recipes-multimedia/r8168/r8168/blacklist.conf
@@ -1,1 +1,0 @@
-blacklist pgdrv


### PR DESCRIPTION
For r8168:
                    Renamed `blacklist.conf` → `blacklist-eth.conf`
                    Updated `blacklist.conf` → `blacklist-eth.conf` in r8168.bb
                    
For kernel-module-nxp-wlan:
                   Renamed `blacklist.conf` → `blacklist-wifi-bt.conf`
                   Updated `blacklist.conf` → `blacklist-wifi-bt.conf`  in  kernel-module-nxp-wlan.bbappend