### PR TITLE
Upgrade BSP to version 6.6.52_2.2.0

### DIFF
--- a/conf/adlink-conf/lec-imx8mp/bblayers.conf.append
+++ b/conf/adlink-conf/lec-imx8mp/bblayers.conf.append
@@ -1,4 +1,4 @@
-
+BBLAYERS += "${BSPDIR}/sources/meta-browser/meta-chromium"
 # ADLINK Yocto Project Release layers
 BBLAYERS += "${BSPDIR}/sources/meta-adlink-nxp"
 BBLAYERS += "${BSPDIR}/sources/meta-adlink-sema"

--- a/conf/machine/lec-imx8mp.conf
+++ b/conf/machine/lec-imx8mp.conf
@@ -95,8 +95,8 @@ WIC_PARTITION_TABLE_TYPE = "msdos"
 WIC_FSTAB_BLKDEV = "mmcblk2"
 IMAGE_FSTYPES:append = " wic wic.md5sum"
 WKS_FILE_DEPENDS:append = " imx-m7-demos"
-IMAGE_BOOT_FILES += "imx8mp_m7_TCM_hello_world.bin \
-                    imx8mp_m7_TCM_rpmsg_lite_pingpong_rtos_linux_remote.bin \
-                    imx8mp_m7_TCM_rpmsg_lite_str_echo_rtos.bin \
-                    imx8mp_m7_TCM_sai_low_power_audio.bin \
+IMAGE_BOOT_FILES += "mcore-demos/imx8mp_m7_TCM_hello_world.bin \
+                    mcore-demos/imx8mp_m7_TCM_rpmsg_lite_pingpong_rtos_linux_remote.bin \
+                    mcore-demos/imx8mp_m7_TCM_rpmsg_lite_str_echo_rtos.bin \
+                    mcore-demos/imx8mp_m7_TCM_sai_low_power_audio.bin \
 "

--- a/recipes-adlink/packagegroups/packagegroup-adlink.bbappend
+++ b/recipes-adlink/packagegroups/packagegroup-adlink.bbappend
@@ -1,15 +1,14 @@
 RDEPENDS:packagegroup-adlink-wifi:append:lec-imx8mp = " \
-    linux-firmware-nxp89xx \
     linux-firmware-nxp8997-sdio \
     linux-firmware-nxp8997-common \	
     nxp-wlan-sdk \
     wireless-tools \
+    firmware-nxp-wifi \
 "
 
 RDEPENDS:packagegroup-adlink-tools:append:lec-imx8mp = " \
     powerled \
     eth-lsoe \
-    test-tools \
     v4lcap-mplane \
 "
 


### PR DESCRIPTION
- Added meta-chromium layer to bblayers.conf.append for Chromium support.
- Updated image boot files to reference new mcore-demos directory structure.
- Updated Wi-Fi firmware dependencies in packagegroup-adlink.bbappend.
- Cleaned up unnecessary dependencies in packagegroup-adlink.bbappend.

These changes align with the BSP upgrade to version 6.6.52_2.2.0.