### PR TITLE
Hotfix for cracklib/glslang/vulkan-loader branch rename issue

### DIFF
--- a/recipes-extended/cracklib/cracklib_%.bbappend
+++ b/recipes-extended/cracklib/cracklib_%.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/cracklib/cracklib;protocol=https;branch=main"

--- a/recipes-extended/glslang/glslang_%.bbappend
+++ b/recipes-extended/glslang/glslang_%.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/KhronosGroup/glslang.git;protocol=https;branch=main"

--- a/recipes-extended/vulkan/vulkan-loader_%.bbappend
+++ b/recipes-extended/vulkan/vulkan-loader_%.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Loader.git;branch=main;protocol=https"


### PR DESCRIPTION
Updated branch from master to main for cracklib, glslang, and vulkan-loader 