### PR TITLE
Hotfix for cracklib/glslang/vulkan-loader branch rename issue

### DIFF
--- a/recipes-extended/cracklib/cracklib_%.bbappend
+++ b/recipes-extended/cracklib/cracklib_%.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/cracklib/cracklib;protocol=https;branch=main"

--- a/recipes-graphics/glslang/glslang_%.bbappend
+++ b/recipes-graphics/glslang/glslang_%.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/KhronosGroup/glslang.git;protocol=https;branch=main"

--- a/recipes-graphics/vulkan/vulkan-loader_%.bbappend
+++ b/recipes-graphics/vulkan/vulkan-loader_%.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Loader.git;branch=main;protocol=https"


### PR DESCRIPTION


Update the branch by moving following recipe [cracklib, glslang, and vulkan-loader] from master to main 