### PR TITLE
Use pcf8563 as primary rtc

### DIFF
--- a/recipes-kernel/linux/linux-imx/lec-imx8mp/lec-imx8mp.dts
+++ b/recipes-kernel/linux/linux-imx/lec-imx8mp/lec-imx8mp.dts
@@ -16,6 +16,11 @@
 	model = "ADLINK LEC-iMX8MP SOM module";
 	compatible = "fsl,imx8mp-evk", "fsl,imx8mp", "adlink,lec-imx8mp";
 
+    aliases {
+		rtc0 = &pcf8563;        /* Use external I2C RTC PCF8563 as rtc0 */
+		rtc1 = &snvs_rtc;       /* And the internal one as rtc1 */
+	}
+
 	chosen {
 		stdout-path = &uart2;
 	};


### PR DESCRIPTION
Introduce aliases to map the external rtc to rtc0.

This should also be added on master (maybe also other branches). Might also be interesting for other platforms.