### PR TITLE
Correct aliases tag in device tree file

### DIFF
--- a/recipes-kernel/linux/linux-imx/lec-imx8mp/lec-imx8mp.dts
+++ b/recipes-kernel/linux/linux-imx/lec-imx8mp/lec-imx8mp.dts
@@ -19,7 +19,7 @@
     aliases {
 		rtc0 = &pcf8563;        /* Use external I2C RTC PCF8563 as rtc0 */
 		rtc1 = &snvs_rtc;       /* And the internal one as rtc1 */
-	}
+	};
 
 	chosen {
 		stdout-path = &uart2;


### PR DESCRIPTION
Unfortunately a closing semicolon was missing for the aliases tag.