### PR TITLE
Fix unused variable warning in tlv320aic3x codec patches

### DIFF
--- a/recipes-kernel/linux/linux-imx/lec-imx8mm/0010-Added-tlv320aic3x-codec-support.patch
+++ b/recipes-kernel/linux/linux-imx/lec-imx8mm/0010-Added-tlv320aic3x-codec-support.patch
@@ -104,11 +104,11 @@ index 000000000000..20f30bbe7608
 +{
 +	struct imx_tlv320aic3x_data *data = container_of(rtd->card,
 +					struct imx_tlv320aic3x_data, card);
-+	struct snd_soc_dai *codec_dai = asoc_rtd_to_cpu(rtd, 0);				
++	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
 +	struct device *dev = rtd->card->dev;
 +	int ret;
 +
-+	ret = snd_soc_dai_set_sysclk(asoc_rtd_to_codec(rtd, 0), 0,data->clk_frequency, SND_SOC_CLOCK_IN);
++	ret = snd_soc_dai_set_sysclk(codec_dai, 0,data->clk_frequency, SND_SOC_CLOCK_IN);
 +	if (ret) {
 +		dev_err(dev, "could not set codec driver clock params\n");
 +		return ret;

--- a/recipes-kernel/linux/linux-imx/lec-imx8mp/0001-Added-LEC-IMX8MP--board-support-based-on-i.MX8MP.patch
+++ b/recipes-kernel/linux/linux-imx/lec-imx8mp/0001-Added-LEC-IMX8MP--board-support-based-on-i.MX8MP.patch
@@ -5419,11 +5419,11 @@ index 0000000000000..4dcaef80216a2
 +{
 +	struct imx_tlv320aic3x_data *data = container_of(rtd->card,
 +					struct imx_tlv320aic3x_data, card);
-+	struct snd_soc_dai *codec_dai = asoc_rtd_to_cpu(rtd, 0);				
++	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
 +	struct device *dev = rtd->card->dev;
 +	int ret;
 +
-+	ret = snd_soc_dai_set_sysclk(asoc_rtd_to_codec(rtd, 0), 0,
++	ret = snd_soc_dai_set_sysclk(codec_dai, 0,
 +				     data->clk_frequency, SND_SOC_CLOCK_IN);
 +	if (ret) {
 +		dev_err(dev, "could not set codec driver clock params\n");

--- a/recipes-kernel/linux/linux-imx/osm-imx93/0002-Added-TLV320AIC3X-codec-support.patch
+++ b/recipes-kernel/linux/linux-imx/osm-imx93/0002-Added-TLV320AIC3X-codec-support.patch
@@ -170,11 +170,11 @@ index 000000000000..20f30bbe7608
 +{
 +	struct imx_tlv320aic3x_data *data = container_of(rtd->card,
 +					struct imx_tlv320aic3x_data, card);
-+	struct snd_soc_dai *codec_dai = asoc_rtd_to_cpu(rtd, 0);				
++	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
 +	struct device *dev = rtd->card->dev;
 +	int ret;
 +
-+	ret = snd_soc_dai_set_sysclk(asoc_rtd_to_codec(rtd, 0), 0,data->clk_frequency, SND_SOC_CLOCK_IN);
++	ret = snd_soc_dai_set_sysclk(codec_dai, 0,data->clk_frequency, SND_SOC_CLOCK_IN);
 +	if (ret) {
 +		dev_err(dev, "could not set codec driver clock params\n");
 +		return ret;


### PR DESCRIPTION
Use already declared codec_dai pointer variable for setting sysclk.
This prevents build failures when building with -Wunsed-variable and -Werror.